### PR TITLE
change the schema of naming librepair-experiments branches

### DIFF
--- a/jtravis/src/test/java/fr/inria/spirals/jtravis/helpers/BuildHelperTest.java
+++ b/jtravis/src/test/java/fr/inria/spirals/jtravis/helpers/BuildHelperTest.java
@@ -249,7 +249,7 @@ public class BuildHelperTest {
     public void testGetTheLastBuildNumberOfADate() {
         Date date = TestUtils.getDate(2017, 3, 16, 22, 59, 59);
 
-        String slug = "Spirals-Team/librepair";
+        String slug = "Spirals-Team/repairnator";
 
         int expectedBuildNumber = 215;
 
@@ -262,7 +262,7 @@ public class BuildHelperTest {
     public void testGetTheLastBuildNumberOfADate2() {
         Date date = TestUtils.getDate(2017, 3, 14, 22, 59, 59);
 
-        String slug = "Spirals-Team/librepair";
+        String slug = "Spirals-Team/repairnator";
 
         int expectedBuildNumber = 189;
 
@@ -274,7 +274,7 @@ public class BuildHelperTest {
     @Test
     public void testGetBuildsFromRepositoryInTimeInterval() {
         Repository repo = new Repository();
-        repo.setSlug("Spirals-Team/librepair");
+        repo.setSlug("Spirals-Team/repairnator");
 
         Date initialDate = TestUtils.getDate(2017, 3, 13, 23, 0, 0);
 

--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
@@ -125,11 +125,7 @@ public class ProjectInspector {
     public String getRemoteBranchName() {
         SimpleDateFormat dateFormat = new SimpleDateFormat("YYYYMMdd-HHmmss");
         String formattedDate = dateFormat.format(this.getBuggyBuild().getFinishedAt());
-        if (this.buildToBeInspected.getStatus() == ScannedBuildStatus.ONLY_FAIL) {
-            return this.getRepoSlug().replace('/', '-') + '-' + this.getBuggyBuild().getId() + '-' + formattedDate + "_bugonly";
-        } else {
-            return this.getRepoSlug().replace('/', '-') + '-' + this.getBuggyBuild().getId() + '-' + formattedDate;
-        }
+        return this.getRepoSlug().replace('/', '-') + '-' + this.getBuggyBuild().getId() + '-' + formattedDate;
     }
 
     public void run() {

--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
@@ -124,12 +124,11 @@ public class ProjectInspector {
 
     public String getRemoteBranchName() {
         SimpleDateFormat dateFormat = new SimpleDateFormat("YYYYMMdd-HHmmss");
+        String formattedDate = dateFormat.format(this.getBuggyBuild().getFinishedAt());
         if (this.buildToBeInspected.getStatus() == ScannedBuildStatus.ONLY_FAIL) {
-            String formattedDate = dateFormat.format(this.getBuggyBuild().getFinishedAt());
             return this.getRepoSlug().replace('/', '-') + '-' + this.getBuggyBuild().getId() + '-' + formattedDate + "_bugonly";
         } else {
-            String formattedDate = dateFormat.format(this.getPatchedBuild().getFinishedAt());
-            return this.getRepoSlug().replace('/', '-') + '-' + this.getPatchedBuild().getId() + '-' + formattedDate;
+            return this.getRepoSlug().replace('/', '-') + '-' + this.getBuggyBuild().getId() + '-' + formattedDate;
         }
     }
 

--- a/repairnator/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/TestProjectInspector.java
+++ b/repairnator/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/TestProjectInspector.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyString;
@@ -122,6 +123,9 @@ public class TestProjectInspector {
         assertThat(jobStatus.getPushState(), is(PushState.REPAIR_INFO_COMMITTED));
         assertThat(jobStatus.getFailureLocations().size(), is(1));
         assertThat(jobStatus.getMetrics().getFailureNames().size(), is(1));
+
+        String remoteBranchName = "surli-failingProject-208897371-20170308-100702";
+        assertEquals(remoteBranchName, inspector.getRemoteBranchName());
 
         verify(notifierEngine, times(1)).notify(anyString(), anyString());
         verify(serializerEngine, times(1)).serialize(anyListOf(SerializedData.class), eq(SerializerType.INSPECTOR));

--- a/repairnator/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/TestProjectInspector.java
+++ b/repairnator/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/TestProjectInspector.java
@@ -124,7 +124,7 @@ public class TestProjectInspector {
         assertThat(jobStatus.getFailureLocations().size(), is(1));
         assertThat(jobStatus.getMetrics().getFailureNames().size(), is(1));
 
-        String remoteBranchName = "surli-failingProject-208897371-20170308-100702";
+        String remoteBranchName = "surli-failingProject-208897371-20170308-040702";
         assertEquals(remoteBranchName, inspector.getRemoteBranchName());
 
         verify(notifierEngine, times(1)).notify(anyString(), anyString());


### PR DESCRIPTION
branch name should not be identified by the patched buildid as we do not store it in the mongodb. Instead we should ALWAYS use the buggybuildid. 