### PR TITLE
Fix issue related to the serialization of detailed data from scanner in Bears mode.

### DIFF
--- a/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/Launcher.java
+++ b/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/Launcher.java
@@ -160,12 +160,6 @@ public class Launcher {
         sw1.setDefault("false");
         this.jsap.registerParameter(sw1);
 
-        sw1 = new Switch("scanOnly");
-        sw1.setLongFlag("scan-only");
-        sw1.setDefault("false");
-        sw1.setHelp("Use it when the scanner is not used to launch the pipeline to gather more datas in spreadsheet.");
-        this.jsap.registerParameter(sw1);
-
         sw1 = new Switch("skip-failing");
         sw1.setLongFlag("skip-failing");
         sw1.setDefault("false");
@@ -305,11 +299,8 @@ public class Launcher {
             scannerSerializer = new ScannerSerializer(this.engines, scanner);
         } else {
             scannerSerializer = new ScannerSerializer4Bears(this.engines, scanner);
-
-            if (this.arguments.getBoolean("scanOnly")) {
-                ScannerDetailedDataSerializer scannerDetailedDataSerializer = new ScannerDetailedDataSerializer(this.engines, buildsToBeInspected);
-                scannerDetailedDataSerializer.serialize();
-            }
+            ScannerDetailedDataSerializer scannerDetailedDataSerializer = new ScannerDetailedDataSerializer(this.engines, buildsToBeInspected);
+            scannerDetailedDataSerializer.serialize();
         }
 
         scannerSerializer.serialize();


### PR DESCRIPTION
The serialization of detailed data from scanner for Bears was not happening, because the control argument `scanOnly` was not being passed to the scanner. This argument had been used only for this, and the serialization of detailed data from scanner for Bears should happen independently if the launcher is only for scan or not, thus I just removed this argument from scanner.