### PR TITLE
Fix date interval for scanning builds.

### DIFF
--- a/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/Utils.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/Utils.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -76,4 +77,15 @@ public class Utils {
             return null;
         }
     }
+
+    public static Date getLastTimeFromDate(Date date) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        calendar.set(Calendar.HOUR_OF_DAY, calendar.getMaximum(Calendar.HOUR_OF_DAY));
+        calendar.set(Calendar.MINUTE, calendar.getMaximum(Calendar.MINUTE));
+        calendar.set(Calendar.SECOND, calendar.getMaximum(Calendar.SECOND));
+        calendar.set(Calendar.MILLISECOND, calendar.getMaximum(Calendar.MILLISECOND));
+        return calendar.getTime();
+    }
+
 }

--- a/repairnator/repairnator-core/src/test/java/fr/inria/spirals/repairnator/TestSerializerUtils.java
+++ b/repairnator/repairnator-core/src/test/java/fr/inria/spirals/repairnator/TestSerializerUtils.java
@@ -2,6 +2,8 @@ package fr.inria.spirals.repairnator;
 
 import org.junit.Test;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -50,4 +52,24 @@ public class TestSerializerUtils {
 
         assertThat(humanString, is("03:21"));
     }
+
+    @Test
+    public void testGetLastTimeFromDate() {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd/MM/yyyy");
+        SimpleDateFormat simpleDateFormatAux = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
+
+        Date date = null;
+        try {
+            date = simpleDateFormat.parse("01/01/2017");
+
+            Date obtainedDate = Utils.getLastTimeFromDate(date);
+
+            String expectedStr = "01/01/2017 23:59:59";
+
+            assertThat(simpleDateFormatAux.format(obtainedDate), is(expectedStr));
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+    }
+
 }

--- a/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/Launcher.java
+++ b/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/Launcher.java
@@ -224,14 +224,14 @@ public class Launcher {
         opt2.setShortFlag('f');
         opt2.setLongFlag("lookFromDate");
         opt2.setStringParser(dateStringParser);
-        opt2.setHelp("Specify the initial date to get builds");
+        opt2.setHelp("Specify the initial date to get builds (e.g. 01/01/2017). Note that the search starts from 00:00:00 of the specified date.");
         this.jsap.registerParameter(opt2);
 
         opt2 = new FlaggedOption("lookToDate");
         opt2.setShortFlag('t');
         opt2.setLongFlag("lookToDate");
         opt2.setStringParser(dateStringParser);
-        opt2.setHelp("Specify the final date to get builds");
+        opt2.setHelp("Specify the final date to get builds (e.g. 31/01/2017). Note that the search is until 23:59:59 of the specified date.");
         this.jsap.registerParameter(opt2);
 
         opt2 = new FlaggedOption("googleSecretPath");
@@ -287,6 +287,15 @@ public class Launcher {
         ProjectScanner scanner;
         Date lookFromDate = this.arguments.getDate("lookFromDate");
         Date lookToDate = this.arguments.getDate("lookToDate");
+        if (lookToDate != null) {
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(lookToDate);
+            calendar.set(Calendar.HOUR_OF_DAY, calendar.getMaximum(Calendar.HOUR_OF_DAY));
+            calendar.set(Calendar.MINUTE, calendar.getMaximum(Calendar.MINUTE));
+            calendar.set(Calendar.SECOND, calendar.getMaximum(Calendar.SECOND));
+            calendar.set(Calendar.MILLISECOND, calendar.getMaximum(Calendar.MILLISECOND));
+            lookToDate = calendar.getTime();
+        }
         if (lookFromDate != null && lookToDate != null && lookFromDate.before(lookToDate)) {
             scanner = new ProjectScanner(lookFromDate, lookToDate, launcherMode, this.arguments.getString("runId"), this.arguments.getBoolean("skip-failing"));
         } else {

--- a/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/Launcher.java
+++ b/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/Launcher.java
@@ -288,13 +288,7 @@ public class Launcher {
         Date lookFromDate = this.arguments.getDate("lookFromDate");
         Date lookToDate = this.arguments.getDate("lookToDate");
         if (lookToDate != null) {
-            Calendar calendar = Calendar.getInstance();
-            calendar.setTime(lookToDate);
-            calendar.set(Calendar.HOUR_OF_DAY, calendar.getMaximum(Calendar.HOUR_OF_DAY));
-            calendar.set(Calendar.MINUTE, calendar.getMaximum(Calendar.MINUTE));
-            calendar.set(Calendar.SECOND, calendar.getMaximum(Calendar.SECOND));
-            calendar.set(Calendar.MILLISECOND, calendar.getMaximum(Calendar.MILLISECOND));
-            lookToDate = calendar.getTime();
+            lookToDate = Utils.getLastTimeFromDate(lookToDate);
         }
         if (lookFromDate != null && lookToDate != null && lookFromDate.before(lookToDate)) {
             scanner = new ProjectScanner(lookFromDate, lookToDate, launcherMode, this.arguments.getString("runId"), this.arguments.getBoolean("skip-failing"));

--- a/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
+++ b/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
@@ -4,6 +4,7 @@ import fr.inria.jtravis.entities.*;
 import fr.inria.jtravis.helpers.BuildHelper;
 import fr.inria.jtravis.helpers.RepositoryHelper;
 import fr.inria.spirals.repairnator.BuildToBeInspected;
+import fr.inria.spirals.repairnator.Utils;
 import fr.inria.spirals.repairnator.states.LauncherMode;
 import fr.inria.spirals.repairnator.states.ScannedBuildStatus;
 import org.kohsuke.github.*;
@@ -54,6 +55,8 @@ public class ProjectScanner {
         this.repositories = new HashSet<Repository>();
         this.runId = runId;
         this.skipFailing = skipFailing;
+
+        this.logger.info("Look from " + Utils.formatCompleteDate(this.lookFromDate) + " to " + Utils.formatCompleteDate(this.lookToDate));
     }
 
     public String getRunId() {


### PR DESCRIPTION
_How the scanner has worked when giving an interval of dates to scan builds:_

For both dates, i.e. `lookFrom` and `lookTo`, the scanner has got it at midnight. Thus, if I want to scan only one day, let's say 31/01/1991, I need to enter `lookFrom=31/01/1991` and `lookTo=01/02/1991`, which looks like strange for potential users (aka me). Moreover, despite the fact it is improbable to happen, if a build happened at 01/02/1991 00:00:00, I will get it, even that I wanted builds only from the day 31/01/1991. If I search two intervals, `lookFrom=31/01/1991` and `lookTo=01/02/1991`, and `lookFrom=01/02/1991` and `lookTo=02/02/1991`, in both searches, the scanner will return the same build that happened at 01/02/1991 00:00:00.

_Proposal:_

To make `lookTo` just before midnight. In the example, then, I would enter `lookFrom=31/01/1991` and `lookTo=31/01/1991`, and the scan would happen from 00:00:00 to 23:59:59 at 31/01/1991.