### PR TITLE
Remove skip-failing arg from scanner

### DIFF
--- a/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -329,12 +329,6 @@ public class LauncherUtils {
         if (getArgHelp(arguments)) {
             printUsage(jsap, launcherType);
         }
-
-        if (launcherType == LauncherType.SCANNER) {
-            if (!(LauncherUtils.getArgLauncherMode(arguments) == LauncherMode.BEARS) && arguments.getBoolean("skip-failing")) {
-                printUsage(jsap, launcherType);
-            }
-        }
     }
 
     public static void checkEnvironmentVariables(JSAP jsap, LauncherType launcherType) {

--- a/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/Launcher.java
+++ b/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/Launcher.java
@@ -184,7 +184,7 @@ public class Launcher {
             scanner = new ProjectScanner(lookFromDate, lookToDate, this.config.getRunId());
         }
 
-        List<BuildToBeInspected> buildsToBeInspected = scanner.getListOfBuildsToBeInspected(LauncherUtils.getArgInput(this.arguments).getPath());
+        List<BuildToBeInspected> buildsToBeInspected = scanner.getListOfBuildsToBeInspectedFromProjects(LauncherUtils.getArgInput(this.arguments).getPath());
         ProcessSerializer scannerSerializer;
 
         if (this.config.getLauncherMode() == LauncherMode.REPAIR) {

--- a/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/Launcher.java
+++ b/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/Launcher.java
@@ -84,12 +84,6 @@ public class Launcher {
         // --notifyto
         this.jsap.registerParameter(LauncherUtils.defineArgNotifyto());
 
-        Switch sw1 = new Switch("skip-failing");
-        sw1.setLongFlag("skip-failing");
-        sw1.setDefault("false");
-        sw1.setHelp("Use it when the scanner should skip failing builds (can be used only with bears mode)");
-        this.jsap.registerParameter(sw1);
-
         FlaggedOption opt2 = new FlaggedOption("lookupHours");
         opt2.setShortFlag('l');
         opt2.setLongFlag("lookupHours");
@@ -167,14 +161,14 @@ public class Launcher {
             lookToDate = Utils.getLastTimeFromDate(lookToDate);
         }
         if (lookFromDate != null && lookToDate != null && lookFromDate.before(lookToDate)) {
-            scanner = new ProjectScanner(lookFromDate, lookToDate, launcherMode, LauncherUtils.getArgRunId(this.arguments), this.arguments.getBoolean("skip-failing"));
+            scanner = new ProjectScanner(lookFromDate, lookToDate, launcherMode, LauncherUtils.getArgRunId(this.arguments));
         } else {
             int lookupHours = this.arguments.getInt("lookupHours");
             Calendar limitCal = Calendar.getInstance();
             limitCal.add(Calendar.HOUR_OF_DAY, -lookupHours);
             lookFromDate = limitCal.getTime();
             lookToDate = new Date();
-            scanner = new ProjectScanner(lookFromDate, lookToDate, launcherMode, LauncherUtils.getArgRunId(this.arguments), this.arguments.getBoolean("skip-failing"));
+            scanner = new ProjectScanner(lookFromDate, lookToDate, launcherMode, LauncherUtils.getArgRunId(this.arguments));
         }
 
         List<BuildToBeInspected> buildsToBeInspected = scanner.getListOfBuildsToBeInspected(LauncherUtils.getArgInput(this.arguments).getPath());

--- a/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
+++ b/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
@@ -131,7 +131,7 @@ public class ProjectScanner {
     public List<BuildToBeInspected> getListOfBuildsToBeInspected(String path) throws IOException {
         this.scannerRunningBeginDate = new Date();
 
-        List<BuildToBeInspected> buildsToBeInspected = getListOfBuildsFromProjectsByBuildStatus(path);
+        List<BuildToBeInspected> buildsToBeInspected = getListOfBuildsFromProjects(path);
 
         this.scannerRunningEndDate = new Date();
 
@@ -159,7 +159,7 @@ public class ProjectScanner {
      * @return a list of failing builds
      * @throws IOException
      */
-    private List<BuildToBeInspected> getListOfBuildsFromProjectsByBuildStatus(String path) throws IOException {
+    private List<BuildToBeInspected> getListOfBuildsFromProjects(String path) throws IOException {
         List<String> slugs = getFileContent(path);
         this.totalRepoNumber = slugs.size();
 

--- a/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
+++ b/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
@@ -128,16 +128,6 @@ public class ProjectScanner {
         return hours + ":" + minutes + ":" + seconds;
     }
 
-    public List<BuildToBeInspected> getListOfBuildsToBeInspected(String path) throws IOException {
-        this.scannerRunningBeginDate = new Date();
-
-        List<BuildToBeInspected> buildsToBeInspected = getListOfBuildsFromProjects(path);
-
-        this.scannerRunningEndDate = new Date();
-
-        return buildsToBeInspected;
-    }
-
     private List<String> getFileContent(String path) throws IOException {
         List<String> result = new ArrayList<String>();
         File file = new File(path);
@@ -159,12 +149,16 @@ public class ProjectScanner {
      * @return a list of failing builds
      * @throws IOException
      */
-    private List<BuildToBeInspected> getListOfBuildsFromProjects(String path) throws IOException {
+    public List<BuildToBeInspected> getListOfBuildsToBeInspectedFromProjects(String path) throws IOException {
+        this.scannerRunningBeginDate = new Date();
+
         List<String> slugs = getFileContent(path);
         this.totalRepoNumber = slugs.size();
 
         List<Repository> repos = getListOfValidRepository(slugs);
         List<BuildToBeInspected> builds = getListOfBuildsFromRepo(repos);
+
+        this.scannerRunningEndDate = new Date();
 
         return builds;
     }


### PR DESCRIPTION
The arg `skip-failing` in scanner module is not necessary for Bears. In `ProjectScanner` there is already the variable `targetFailing` to make the things work properly for Bears.

This PR closes the issue #443.