### PR TITLE
Fix syntax error in launch_repairnator.sh

### DIFF
--- a/repairnator/scripts/launch_repairnator.sh
+++ b/repairnator/scripts/launch_repairnator.sh
@@ -45,6 +45,7 @@ if [ "$SKIP_SCAN" -eq 1 ]; then
     SKIP_LAUNCH_REPAIRNATOR=0
 else if [ ! -f "$REPAIR_PROJECT_LIST_PATH" ]; then
     touch $REPAIR_PROJECT_LIST_PATH
+    fi
 fi
 
 if [ -z "$RUN_ID_SUFFIX" ]; then


### PR DESCRIPTION
When running `launch_repairnator.sh`, I got "./launch_repairnator.sh: line 123: syntax error: unexpected end of file". This PR fixes that.