### PR TITLE
Bump all versions

### DIFF
--- a/repairnator/pom.xml
+++ b/repairnator/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>fr.inria.repairnator</groupId>
     <artifactId>repairnator-root</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>repairnator-root</name>
     <inceptionYear>2017</inceptionYear>

--- a/repairnator/repairnator-checkbranches/pom.xml
+++ b/repairnator/repairnator-checkbranches/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>repairnator-root</artifactId>
         <groupId>fr.inria.repairnator</groupId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repairnator/repairnator-core/pom.xml
+++ b/repairnator/repairnator-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>repairnator-root</artifactId>
         <groupId>fr.inria.repairnator</groupId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repairnator/repairnator-dockerpool/pom.xml
+++ b/repairnator/repairnator-dockerpool/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>repairnator-root</artifactId>
         <groupId>fr.inria.repairnator</groupId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repairnator/repairnator-pipeline/pom.xml
+++ b/repairnator/repairnator-pipeline/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>repairnator-root</artifactId>
         <groupId>fr.inria.repairnator</groupId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repairnator/repairnator-realtime/pom.xml
+++ b/repairnator/repairnator-realtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>repairnator-root</artifactId>
         <groupId>fr.inria.repairnator</groupId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repairnator/repairnator-scanner/pom.xml
+++ b/repairnator/repairnator-scanner/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>repairnator-root</artifactId>
         <groupId>fr.inria.repairnator</groupId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/repairnator/scripts/set_env_variable.sh
+++ b/repairnator/scripts/set_env_variable.sh
@@ -52,10 +52,10 @@ export HUMAN_PATCH=0 # Test the human patch for check branches ?
 export SCANNER_VERSION=LATEST
 export DOCKERPOOL_VERSION=LATEST
 export REALTIME_VERSION=LATEST
-export PIPELINE_VERSION=LATEST
+export PIPELINE_VERSION=latest
 
 ### Docker tags
-export DOCKER_TAG=surli/repairnator:latest # Tag of the docker image to use for pipeline
+export DOCKER_TAG=surli/repairnator:$PIPELINE_VERSION # Tag of the docker image to use for pipeline
 export DOCKER_CHECKBRANCHES_TAG=surli/checkbranches:latest # Tag of the docker image to use for checkbranches
 
 ### Root pathes


### PR DESCRIPTION
Repairnator is no more compliant with first release: lots of arguments have changed and the scripts cannot be used anymore with the 1.0. So I proposed to bump everything to version 2.0 right now. So contrary to what I said, next release of the scanner would be 2.0. WDYT @fermadeiral ?