### PR TITLE
Fix LauncherUtils.checkEnvironmentVariable()

### DIFF
--- a/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -284,11 +284,9 @@ public class LauncherUtils {
     }
 
     public static void checkEnvironmentVariable(String envVariable, JSAP jsap, LauncherType launcherType) {
-        if (launcherType != LauncherType.PIPELINE) {
-            if (System.getenv(envVariable) == null || System.getenv(envVariable).equals("")) {
-                System.err.println("You must set the following environment variable: "+envVariable);
-                LauncherUtils.printUsage(jsap, launcherType);
-            }
+        if (System.getenv(envVariable) == null || System.getenv(envVariable).equals("")) {
+            System.err.println("You must set the following environment variable: "+envVariable);
+            LauncherUtils.printUsage(jsap, launcherType);
         }
     }
 

--- a/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -280,7 +280,11 @@ public class LauncherUtils {
             printUsage(jsap, launcherType);
         }
 
-        checkEnvironmentVariable(Utils.GITHUB_OAUTH, jsap, launcherType);
+        if (launcherType != LauncherType.PIPELINE) {
+            checkEnvironmentVariable(Utils.GITHUB_OAUTH, jsap, launcherType);
+        } else {
+            checkEnvironmentVariable(Utils.M2_HOME, jsap, launcherType);
+        }
     }
 
     public static void checkEnvironmentVariable(String envVariable, JSAP jsap, LauncherType launcherType) {

--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/Launcher.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/Launcher.java
@@ -72,7 +72,6 @@ public class Launcher {
         JSAP jsap = this.defineArgs();
         JSAPResult arguments = jsap.parse(args);
         LauncherUtils.checkArguments(jsap, arguments, LauncherType.PIPELINE);
-        LauncherUtils.checkEnvironmentVariable(Utils.M2_HOME, jsap, LauncherType.PIPELINE);
         this.initConfig(arguments);
 
         if (this.config.getLauncherMode() == LauncherMode.REPAIR) {


### PR DESCRIPTION
When running the pipeline module (directly in intelliJ), the execution crashes when it reaches the first step related to maven because `M2_HOME` was not set. Since this is an issue that should be captured at the beginning, I found a bug in the checks when the `Launcher`starts. This PR is supposed to fix that.