### PR TITLE
Fix pipeline launcher for Bears

### DIFF
--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/Launcher.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/Launcher.java
@@ -159,7 +159,7 @@ public class Launcher {
         opt2 = new FlaggedOption("projectsToIgnore");
         opt2.setLongFlag("projectsToIgnore");
         opt2.setDefault("./projects_to_ignore.txt");
-        opt2.setStringParser(FileStringParser.getParser().setMustExist(true).setMustBeFile(true));
+        opt2.setStringParser(FileStringParser.getParser().setMustBeFile(true));
         opt2.setHelp("Specify the file containing a list of projects that the pipeline should deactivate serialization when processing builds from.");
         jsap.registerParameter(opt2);
 


### PR DESCRIPTION
The pipeline was not working for Bears when running it from dockerpool. This is due a bug I introduced when I added the arg `projectsToIgnore`. This PR fixes that.