### PR TITLE
Add check for pushurl arg

### DIFF
--- a/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -245,7 +245,7 @@ public class LauncherUtils {
         FlaggedOption opt = new FlaggedOption("pushUrl");
         opt.setLongFlag("pushurl");
         opt.setStringParser(JSAP.STRING_PARSER);
-        opt.setHelp("Specify repository URL to push data.");
+        opt.setHelp("Specify repository URL to push data on the format https://github.com/user/repo.");
         return opt;
     }
 
@@ -296,12 +296,23 @@ public class LauncherUtils {
         if (launcherType == LauncherType.PIPELINE) {
             checkEnvironmentVariable(Utils.M2_HOME, jsap, launcherType);
         }
+
+        checkPushUrlArg(jsap, arguments, launcherType);
     }
 
     public static void checkEnvironmentVariable(String envVariable, JSAP jsap, LauncherType launcherType) {
         if (System.getenv(envVariable) == null || System.getenv(envVariable).equals("")) {
             System.err.println("You must set the following environment variable: "+envVariable);
             LauncherUtils.printUsage(jsap, launcherType);
+        }
+    }
+
+    public static void checkPushUrlArg(JSAP jsap, JSAPResult arguments, LauncherType launcherType) {
+        if (getArgPushUrl(arguments) != null) {
+            if (!Utils.matchesGithubRepoUrl(getArgPushUrl(arguments))) {
+                System.err.println("The value of the argument pushurl is wrong.");
+                LauncherUtils.printUsage(jsap, launcherType);
+            }
         }
     }
 

--- a/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/Utils.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/Utils.java
@@ -25,6 +25,7 @@ public class Utils {
     private static final SimpleDateFormat fileDateFormat = new SimpleDateFormat("YYYY-MM-dd_HHmm");
     private static final String TRAVIS_URL = "http://travis-ci.org/";
     private static final String GITHUB_URL = "https://github.com/";
+    private static final String GITHUB_REPO_URL_PATTERN = GITHUB_URL+"[\\w_-]+/[\\w_-]+";
     public static final char COMMA = ',';
 
     public static String formatCompleteDate(Date date) {
@@ -54,6 +55,10 @@ public class Utils {
 
     public static String getGithubRepoUrl(String slug) {
         return GITHUB_URL + slug + ".git";
+    }
+
+    public static boolean matchesGithubRepoUrl(String repoUrl) {
+        return repoUrl.matches(GITHUB_REPO_URL_PATTERN);
     }
 
     public static String getDuration(Date dateBegin, Date dateEnd) {

--- a/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/Utils.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/Utils.java
@@ -25,7 +25,10 @@ public class Utils {
     private static final SimpleDateFormat fileDateFormat = new SimpleDateFormat("YYYY-MM-dd_HHmm");
     private static final String TRAVIS_URL = "http://travis-ci.org/";
     private static final String GITHUB_URL = "https://github.com/";
-    private static final String GITHUB_REPO_URL_PATTERN = GITHUB_URL+"[\\w_-]+/[\\w_-]+";
+
+    public static final String GITHUB_USER_NAME_PATTERN = "[a-zA-Z0-9](?:[a-zA-Z0-9]|[-](?=[a-zA-Z0-9]))*";
+    public static final String GITHUB_REPO_NAME_PATTERN = "[a-zA-Z0-9-_.]+(?<!\\.git)";
+    private static final String GITHUB_REPO_URL_PATTERN = GITHUB_URL + GITHUB_USER_NAME_PATTERN + "/" + GITHUB_REPO_NAME_PATTERN;
     public static final char COMMA = ',';
 
     public static String formatCompleteDate(Date date) {

--- a/repairnator/repairnator-core/src/test/java/fr/inria/spirals/repairnator/TestUtils.java
+++ b/repairnator/repairnator-core/src/test/java/fr/inria/spirals/repairnator/TestUtils.java
@@ -15,6 +15,13 @@ public class TestUtils {
     }
 
     @Test
+    public void testMatchesGithubRepoUrlWithRightRepoUrlWithNumber() {
+        String repoUrl = "https://github.com/Sp1r4ls-T34m/r3p41rn4t0r";
+
+        assertThat(Utils.matchesGithubRepoUrl(repoUrl), is(true));
+    }
+
+    @Test
     public void testMatchesGithubRepoUrlWithWrongRepoUrl() {
         String repoUrl = "https://github.com/Spirals-Team/repairnator/";
 
@@ -24,6 +31,13 @@ public class TestUtils {
     @Test
     public void testMatchesGithubRepoUrlWithWrongRepoUrl2() {
         String repoUrl = "https://github.com/Spirals-Team/repairnator.git";
+
+        assertThat(Utils.matchesGithubRepoUrl(repoUrl), is(false));
+    }
+
+    @Test
+    public void testMatchesGithubRepoUrlWithWrongRepoUrlWithNumber() {
+        String repoUrl = "https://github.com/Sp1r4ls-T34m/r3p41rn4t0r.git";
 
         assertThat(Utils.matchesGithubRepoUrl(repoUrl), is(false));
     }

--- a/repairnator/repairnator-core/src/test/java/fr/inria/spirals/repairnator/TestUtils.java
+++ b/repairnator/repairnator-core/src/test/java/fr/inria/spirals/repairnator/TestUtils.java
@@ -8,6 +8,57 @@ import static org.junit.Assert.assertThat;
 public class TestUtils {
 
     @Test
+    public void testGithubUserNamePattern() {
+        String userName = "lucesape";
+        assertThat(userName.matches(Utils.GITHUB_USER_NAME_PATTERN), is(true));
+
+        userName = "LucEsape";
+        assertThat(userName.matches(Utils.GITHUB_USER_NAME_PATTERN), is(true));
+
+        userName = "luc3s4p3";
+        assertThat(userName.matches(Utils.GITHUB_USER_NAME_PATTERN), is(true));
+
+        userName = "luc-esape";
+        assertThat(userName.matches(Utils.GITHUB_USER_NAME_PATTERN), is(true));
+
+        userName = "luc-esape-copy";
+        assertThat(userName.matches(Utils.GITHUB_USER_NAME_PATTERN), is(true));
+
+        userName = "-luc-esape-";
+        assertThat(userName.matches(Utils.GITHUB_USER_NAME_PATTERN), is(false));
+
+        userName = "luc_esape";
+        assertThat(userName.matches(Utils.GITHUB_USER_NAME_PATTERN), is(false));
+    }
+
+    @Test
+    public void testGithubRepoNamePattern() {
+        String repoName = "repairnator";
+        assertThat(repoName.matches(Utils.GITHUB_REPO_NAME_PATTERN), is(true));
+
+        repoName = "RepairNator";
+        assertThat(repoName.matches(Utils.GITHUB_REPO_NAME_PATTERN), is(true));
+
+        repoName = "r3p41rn4t0r";
+        assertThat(repoName.matches(Utils.GITHUB_REPO_NAME_PATTERN), is(true));
+
+        repoName = "repair-nator";
+        assertThat(repoName.matches(Utils.GITHUB_REPO_NAME_PATTERN), is(true));
+
+        repoName = "repair_nator";
+        assertThat(repoName.matches(Utils.GITHUB_REPO_NAME_PATTERN), is(true));
+
+        repoName = "repair.nator";
+        assertThat(repoName.matches(Utils.GITHUB_REPO_NAME_PATTERN), is(true));
+
+        repoName = "repair$nator";
+        assertThat(repoName.matches(Utils.GITHUB_REPO_NAME_PATTERN), is(false));
+
+        repoName = "repairnator.git";
+        assertThat(repoName.matches(Utils.GITHUB_REPO_NAME_PATTERN), is(false));
+    }
+
+    @Test
     public void testMatchesGithubRepoUrlWithRightRepoUrl() {
         String repoUrl = "https://github.com/Spirals-Team/repairnator";
 
@@ -22,22 +73,15 @@ public class TestUtils {
     }
 
     @Test
-    public void testMatchesGithubRepoUrlWithWrongRepoUrl() {
+    public void testMatchesGithubRepoUrlWithWrongRepoUrlWithSlashAtTheEnd() {
         String repoUrl = "https://github.com/Spirals-Team/repairnator/";
 
         assertThat(Utils.matchesGithubRepoUrl(repoUrl), is(false));
     }
 
     @Test
-    public void testMatchesGithubRepoUrlWithWrongRepoUrl2() {
+    public void testMatchesGithubRepoUrlWithWrongRepoUrlWithDotGitAtTheEnd() {
         String repoUrl = "https://github.com/Spirals-Team/repairnator.git";
-
-        assertThat(Utils.matchesGithubRepoUrl(repoUrl), is(false));
-    }
-
-    @Test
-    public void testMatchesGithubRepoUrlWithWrongRepoUrlWithNumber() {
-        String repoUrl = "https://github.com/Sp1r4ls-T34m/r3p41rn4t0r.git";
 
         assertThat(Utils.matchesGithubRepoUrl(repoUrl), is(false));
     }

--- a/repairnator/repairnator-core/src/test/java/fr/inria/spirals/repairnator/TestUtils.java
+++ b/repairnator/repairnator-core/src/test/java/fr/inria/spirals/repairnator/TestUtils.java
@@ -1,0 +1,31 @@
+package fr.inria.spirals.repairnator;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TestUtils {
+
+    @Test
+    public void testMatchesGithubRepoUrlWithRightRepoUrl() {
+        String repoUrl = "https://github.com/Spirals-Team/repairnator";
+
+        assertThat(Utils.matchesGithubRepoUrl(repoUrl), is(true));
+    }
+
+    @Test
+    public void testMatchesGithubRepoUrlWithWrongRepoUrl() {
+        String repoUrl = "https://github.com/Spirals-Team/repairnator/";
+
+        assertThat(Utils.matchesGithubRepoUrl(repoUrl), is(false));
+    }
+
+    @Test
+    public void testMatchesGithubRepoUrlWithWrongRepoUrl2() {
+        String repoUrl = "https://github.com/Spirals-Team/repairnator.git";
+
+        assertThat(Utils.matchesGithubRepoUrl(repoUrl), is(false));
+    }
+
+}


### PR DESCRIPTION
This PR intends to fix issue #168.
I thought on two ways to fix the mentioned issue:
1) To try to repair the push url in the push step (last step of the pipeline)
2) To check the correctness of the push url when other variables are also checked (before the pipeline starts)

I took the second way, since the first way might not work depending on how wrong the push url is, and the user of repairnator would know there was a problem at pushing only in the end of the execution.
WDYT?

PS: the build is passing in https://github.com/fermadeiral/repairnator/pull/8