### PR TITLE
Remove ghOauth from created files to push

### DIFF
--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/git/GitHelper.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/git/GitHelper.java
@@ -41,6 +41,8 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -400,6 +402,29 @@ public class GitHelper {
                 }
             } catch (IOException e) {
                 getLogger().warn("Error while changing travis file", e);
+            }
+        }
+    }
+
+    public void removeGhOauthFromCreatedFilesToPush(File directory, List<String> fileNames) {
+        String ghOauthPattern = "--ghOauth\\s+[\\w]+";
+        for (String fileName : fileNames) {
+            File file = new File(directory, fileName);
+
+            if (!file.exists()) {
+                getLogger().warn("The file "+file.toPath()+" does not exist.");
+            } else {
+                Charset charset = StandardCharsets.UTF_8;
+                try {
+                    String content = new String(Files.readAllBytes(file.toPath()), charset);
+                    String updatedContent = content.replaceAll(ghOauthPattern, "");
+                    if (!content.equals(updatedContent)) {
+                        getLogger().info("ghOauth info detected in file "+file.toPath()+". Such file will be changed.");
+                        Files.write(file.toPath(), updatedContent.getBytes(charset));
+                    }
+                } catch (IOException e) {
+                    getLogger().warn("Error while checking if file "+file.toPath()+" contains ghOauth info.", e);
+                }
             }
         }
     }

--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/git/GitHelper.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/git/GitHelper.java
@@ -417,7 +417,7 @@ public class GitHelper {
                 Charset charset = StandardCharsets.UTF_8;
                 try {
                     String content = new String(Files.readAllBytes(file.toPath()), charset);
-                    String updatedContent = content.replaceAll(ghOauthPattern, "");
+                    String updatedContent = content.replaceAll(ghOauthPattern, "[REMOVED]");
                     if (!content.equals(updatedContent)) {
                         getLogger().info("ghOauth info detected in file "+file.toPath()+". Such file will be changed.");
                         Files.write(file.toPath(), updatedContent.getBytes(charset));

--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/CommitFiles.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/CommitFiles.java
@@ -49,6 +49,8 @@ public class CommitFiles extends AbstractStep {
 
                 gitHelper.removeNotificationFromTravisYML(targetDir, this);
 
+                gitHelper.removeGhOauthFromCreatedFilesToPush(targetDir, this.getInspector().getJobStatus().getCreatedFilesToPush());
+
                 git.add().addFilepattern(".").call();
 
                 gitHelper.gitAdd(this.getInspector().getJobStatus().getCreatedFilesToPush(), git);


### PR DESCRIPTION
This PR intends to fix issue #588.

I run repairnator to REPAIR the build 384520172, which was the build that exposed the bug. The changes work, mainly because I didn't receive an email from GitHub after the branch was generated: https://github.com/fermadeiral/bears-collection-fp/tree/marlon123-spring-api-rest-curso-384520172-20180527-202310

PS: the build is passing in https://github.com/fermadeiral/repairnator/pull/9