### PR TITLE
Change format of branch name for Bears

### DIFF
--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector4Bears.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector4Bears.java
@@ -35,6 +35,10 @@ public class ProjectInspector4Bears extends ProjectInspector {
         this.bug = false;
     }
 
+    public String getRemoteBranchName() {
+        return this.getRepoSlug().replace('/', '-') + '-' + this.getBuggyBuild().getId() + '-' + this.getPatchedBuild().getId();
+    }
+
     public void run() {
         AbstractStep cloneRepo = new CloneRepository(this);
 


### PR DESCRIPTION
This PR changes the format of branch name for Bears. The resulted branches will have the format `<project slug>-<buggy build id>-<fixer build id>`.
The build is passing in https://github.com/fermadeiral/repairnator/pull/17