### PR TITLE
Ready: Improve mail notification for end of process

### DIFF
--- a/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/notifier/EndProcessNotifier.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/notifier/EndProcessNotifier.java
@@ -22,7 +22,9 @@ public class EndProcessNotifier {
 
     public void notifyEnd() {
         String subject = "Process "+processName+" on "+Utils.getHostname()+" finished";
-        String message = "The following process: "+processName+" launched on "+ Utils.getHostname()+" the "+this.launchDate.toString()+" has just finished the "+new Date().toString()+".";
+        Date endDate = new Date();
+        String message = "The following process: "+ processName +" launched on "+ Utils.getHostname()+ " the "+ this.launchDate.toString()+" and finished "+endDate.toString()+". "
+                + "It ran for a total time of "+Utils.getDuration(this.launchDate, endDate);
 
         for (NotifierEngine engine : this.engines) {
             engine.notify(subject, message);


### PR DESCRIPTION
Attempt at resolving issue #546. 

If I have understood the end of process notification correctly, then the start and end of the repair attempt was already mentioned in the mail. The only thing lacking was the duration, or if duration is not the same as uptime I have made a mistake. Should I perhaps `config.getInstance().getDuration().toString()` instead?