### PR TITLE
Add DockerHelper in core module

### DIFF
--- a/repairnator/repairnator-checkbranches/pom.xml
+++ b/repairnator/repairnator-checkbranches/pom.xml
@@ -12,11 +12,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.spotify</groupId>
-            <artifactId>docker-client</artifactId>
-            <version>8.1.2</version>
-        </dependency>
-        <dependency>
             <groupId>fr.inria.repairnator</groupId>
             <artifactId>repairnator-core</artifactId>
             <version>2.3-SNAPSHOT</version>

--- a/repairnator/repairnator-core/pom.xml
+++ b/repairnator/repairnator-core/pom.xml
@@ -20,5 +20,10 @@
             <artifactId>javax.mail</artifactId>
             <version>1.5.6</version>
         </dependency>
+        <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-client</artifactId>
+            <version>8.11.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/docker/DockerHelper.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/spirals/repairnator/docker/DockerHelper.java
@@ -1,0 +1,48 @@
+package fr.inria.spirals.repairnator.docker;
+
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerCertificateException;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.Image;
+
+import java.util.List;
+
+public class DockerHelper {
+
+    public static DockerClient initDockerClient() {
+        DockerClient docker;
+        try {
+            docker = DefaultDockerClient.fromEnv().build();
+        } catch (DockerCertificateException e) {
+            throw new RuntimeException("Error while initializing docker client.");
+        }
+        return docker;
+    }
+
+    public static String findDockerImage(String imageName, DockerClient docker) {
+        if (docker == null) {
+            throw new RuntimeException("Docker client has not been initialized. No docker image can be found.");
+        }
+
+        try {
+            List<Image> allImages = docker.listImages(DockerClient.ListImagesParam.allImages());
+
+            String imageId = null;
+            for (Image image : allImages) {
+                if (image.repoTags() != null && image.repoTags().contains(imageName)) {
+                    imageId = image.id();
+                    break;
+                }
+            }
+
+            if (imageId == null) {
+                throw new RuntimeException("There was a problem when looking for the docker image with argument \""+imageName+"\": no image has been found.");
+            }
+            return imageId;
+        } catch (InterruptedException|DockerException e) {
+            throw new RuntimeException("Error while looking for the docker image",e);
+        }
+    }
+
+}

--- a/repairnator/repairnator-dockerpool/pom.xml
+++ b/repairnator/repairnator-dockerpool/pom.xml
@@ -12,11 +12,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.spotify</groupId>
-            <artifactId>docker-client</artifactId>
-            <version>8.11.1</version>
-        </dependency>
-        <dependency>
             <groupId>fr.inria.repairnator</groupId>
             <artifactId>repairnator-core</artifactId>
             <version>2.3-SNAPSHOT</version>

--- a/repairnator/repairnator-dockerpool/src/main/java/fr/inria/spirals/repairnator/dockerpool/AbstractPoolManager.java
+++ b/repairnator/repairnator-dockerpool/src/main/java/fr/inria/spirals/repairnator/dockerpool/AbstractPoolManager.java
@@ -1,11 +1,8 @@
 package fr.inria.spirals.repairnator.dockerpool;
 
-import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.exceptions.DockerCertificateException;
-import com.spotify.docker.client.exceptions.DockerException;
-import com.spotify.docker.client.messages.Image;
 import fr.inria.spirals.repairnator.InputBuildId;
+import fr.inria.spirals.repairnator.docker.DockerHelper;
 import fr.inria.spirals.repairnator.dockerpool.serializer.TreatedBuildTracking;
 import fr.inria.spirals.repairnator.serializer.engines.SerializerEngine;
 import org.slf4j.Logger;
@@ -29,41 +26,10 @@ public class AbstractPoolManager {
     private String dockerOutputDir = DEFAULT_OUTPUT_DIR;
     private List<SerializerEngine> engines = new ArrayList<>();
 
-    public void initDockerClient() {
-        try {
-            this.docker = DefaultDockerClient.fromEnv().build();
-        } catch (DockerCertificateException e) {
-            throw new RuntimeException("Error while initializing docker client.");
-        }
-    }
-
-    public String findDockerImage(String imageName) {
-        try {
-            this.initDockerClient();
-            List<Image> allImages = this.docker.listImages(DockerClient.ListImagesParam.allImages());
-
-            String imageId = null;
-            for (Image image : allImages) {
-                if (image.repoTags() != null && image.repoTags().contains(imageName)) {
-                    imageId = image.id();
-                    break;
-                }
-            }
-
-            if (imageId == null) {
-                throw new RuntimeException("There was a problem when looking for the docker image with argument \""+imageName+"\": no image has been found.");
-            }
-            return imageId;
-        } catch (InterruptedException|DockerException e) {
-            throw new RuntimeException("Error while looking for the docker image",e);
-        }
-    }
-
     public DockerClient getDockerClient() {
         if (this.docker == null) {
-            throw new RuntimeException("Docker client not initialized! Call initDockerClient() first.");
+            this.docker = DockerHelper.initDockerClient();
         }
-
         return this.docker;
     }
 

--- a/repairnator/repairnator-dockerpool/src/main/java/fr/inria/spirals/repairnator/dockerpool/Launcher.java
+++ b/repairnator/repairnator-dockerpool/src/main/java/fr/inria/spirals/repairnator/dockerpool/Launcher.java
@@ -8,6 +8,7 @@ import fr.inria.spirals.repairnator.InputBuildId;
 import fr.inria.spirals.repairnator.LauncherType;
 import fr.inria.spirals.repairnator.LauncherUtils;
 import fr.inria.spirals.repairnator.Utils;
+import fr.inria.spirals.repairnator.docker.DockerHelper;
 import fr.inria.spirals.repairnator.notifier.EndProcessNotifier;
 import fr.inria.spirals.repairnator.notifier.engines.NotifierEngine;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
@@ -209,7 +210,7 @@ public class Launcher extends AbstractPoolManager {
 
         endProcessSerializer.setNbBuilds(buildIds.size());
 
-        String imageId = this.findDockerImage(this.config.getDockerImageName());
+        String imageId = DockerHelper.findDockerImage(this.config.getDockerImageName(), this.getDockerClient());
         LOGGER.info("Found the following docker image id: "+imageId);
 
         this.setDockerOutputDir(this.config.getLogDirectory());

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/BuildRunner.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/BuildRunner.java
@@ -3,6 +3,7 @@ package fr.inria.spirals.repairnator.realtime;
 import fr.inria.jtravis.entities.Build;
 import fr.inria.spirals.repairnator.InputBuildId;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
+import fr.inria.spirals.repairnator.docker.DockerHelper;
 import fr.inria.spirals.repairnator.dockerpool.AbstractPoolManager;
 import fr.inria.spirals.repairnator.dockerpool.RunnablePipelineContainer;
 import org.slf4j.Logger;
@@ -45,7 +46,7 @@ public class BuildRunner extends AbstractPoolManager {
     }
 
     private void refreshDockerImage() {
-        this.dockerImageId = this.findDockerImage(this.dockerImageName);
+        this.dockerImageId = DockerHelper.findDockerImage(this.dockerImageName, this.getDockerClient());
         this.limitDateNextRetrieveDockerImage = new Date(new Date().toInstant().plus(DELAY_BETWEEN_DOCKER_IMAGE_REFRESH, ChronoUnit.MINUTES).toEpochMilli());
         LOGGER.debug("Find the following docker image: "+this.dockerImageId);
     }


### PR DESCRIPTION
This PR intends to remove duplicate code between `checkbranches/Launcher` and `dockerpool/AbstractPoolManager`. The class `DockerHelper` was added in the core module for that purpose. WDYT?