### PR TITLE
Check if container exit code is really 0 before serializing it as TREATED

### DIFF
--- a/repairnator/repairnator-dockerpool/src/main/java/fr/inria/spirals/repairnator/dockerpool/RunnablePipelineContainer.java
+++ b/repairnator/repairnator-dockerpool/src/main/java/fr/inria/spirals/repairnator/dockerpool/RunnablePipelineContainer.java
@@ -152,7 +152,11 @@ public class RunnablePipelineContainer implements Runnable {
                 this.removeVolumes(docker);
             }
 
-            serialize("TREATED");
+            if (exitStatus.statusCode() == 0) {
+                serialize("TREATED");
+            } else {
+                serialize("ERROR:CODE" + exitStatus.statusCode());
+            }
         } catch (InterruptedException e) {
             LOGGER.error("Error while running the container for build id "+this.inputBuildId.getBuggyBuildId(), e);
             killDockerContainer(docker, false);


### PR DESCRIPTION
When executing dockerpool, I killed a container and for my surprise, it was serialized as TREATED, which should indicate that the execution of an instance from `RunnablePipelineContainer` was just fine, but in the dockerpool log is possible to see that me killing the container resulted in an exit code different from 0. This PR intends to serialize a `RunnablePipelineContainer` as ERROR instead of TREATED when the container exit code is not 0.