### PR TITLE
Remove detail property as required from json schemas

### DIFF
--- a/repairnator/docker-images/bears-checkbranches-dockerimage/bears-schema.json
+++ b/repairnator/docker-images/bears-checkbranches-dockerimage/bears-schema.json
@@ -816,7 +816,6 @@
               "testClass",
               "testMethod",
               "failureName",
-              "detail",
               "isError"
             ]
           }

--- a/repairnator/docker-images/checkbranches-dockerimage/repairnator-schema.json
+++ b/repairnator/docker-images/checkbranches-dockerimage/repairnator-schema.json
@@ -805,7 +805,6 @@
               "testClass",
               "testMethod",
               "failureName",
-              "detail",
               "isError"
             ]
           }

--- a/resources/bears-schema.json
+++ b/resources/bears-schema.json
@@ -816,7 +816,6 @@
               "testClass",
               "testMethod",
               "failureName",
-              "detail",
               "isError"
             ]
           }

--- a/resources/repairnator-schema.json
+++ b/resources/repairnator-schema.json
@@ -805,7 +805,6 @@
               "testClass",
               "testMethod",
               "failureName",
-              "detail",
               "isError"
             ]
           }


### PR DESCRIPTION
It's not always that there exists a failure message for a failed test case, which has been used to set the property "detail" in the json files. This property has been "required" in the json schemas, which makes the "checking branches" to fail on branches that the failed test cases do not have failure message. This PR removes the obligatoriness of this property in the json files.