### PR TITLE
Fix scanner for Bears

### DIFF
--- a/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
+++ b/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
@@ -271,35 +271,14 @@ public class ProjectScanner {
             if (build.getState() == StateType.FAILED) {
                 this.totalBuildInJavaFailing++;
 
-                for (Job job : build.getJobs()) {
-                    RepairnatorConfig.getInstance().getJTravis().refresh(job);
-                    if (job.getState() == StateType.FAILED) {
-                        Optional<Log> optionalLog = job.getLog();
-
-                        if (optionalLog.isPresent()) {
-                            Log jobLog = optionalLog.get();
-                            if (jobLog.getBuildTool() == BuildTool.MAVEN) {
-                                TestsInformation testInfo = jobLog.getTestsInformation();
-
-                                // testInfo can be null if the build tool is unknown
-                                if (testInfo != null && (testInfo.getFailing() > 0 || testInfo.getErrored() > 0)) {
-                                    this.totalBuildInJavaFailingWithFailingTests++;
-                                    if (RepairnatorConfig.getInstance().getLauncherMode() == LauncherMode.REPAIR) {
-                                        this.slugs.add(repo.getSlug());
-                                        this.repositories.add(repo);
-                                        return true;
-                                    } else {
-                                        return false;
-                                    }
-                                } else {
-                                    logger.debug("No failing or erroring test found in build " + build.getId());
-                                }
-                            } else {
-                                logger.debug("Maven is not used in the build " + build.getId());
-                            }
-                        } else {
-                            logger.error("Error while getting a job log: (jobId: " + job.getId() + ")");
-                        }
+                if (isFailedBuildFailingByTestFailure(build)) {
+                    this.totalBuildInJavaFailingWithFailingTests++;
+                    if (RepairnatorConfig.getInstance().getLauncherMode() == LauncherMode.REPAIR) {
+                        this.slugs.add(repo.getSlug());
+                        this.repositories.add(repo);
+                        return true;
+                    } else {
+                        return false;
                     }
                 }
             } else if (build.getState() == StateType.PASSED) {

--- a/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
+++ b/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
@@ -230,6 +230,8 @@ public class ProjectScanner {
                 Optional<Build> optionalBeforeBuild = this.jTravis.build().getBefore(build, true);
                 if (optionalBeforeBuild.isPresent()) {
                     Build previousBuild = optionalBeforeBuild.get();
+                    // FIXME: the next line can be removed once the issue https://github.com/Spirals-Team/jtravis/issues/21 is fixed in jtravis.
+                    previousBuild = jTravis.build().getEntityFromUri(Build.class, previousBuild.getUri()).get();
                     this.logger.debug("Previous build: " + previousBuild.getId());
 
                     BearsMode mode = RepairnatorConfig.getInstance().getBearsMode();

--- a/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
+++ b/repairnator/repairnator-scanner/src/main/java/fr/inria/spirals/repairnator/scanner/ProjectScanner.java
@@ -346,7 +346,7 @@ public class ProjectScanner {
         if (compare != null) {
             GHCommit.File[] modifiedFiles = compare.getFiles();
             for (GHCommit.File file : modifiedFiles) {
-                if (file.getFileName().endsWith(".java") && !file.getFileName().toLowerCase().contains("test")) {
+                if (file.getFileName().endsWith(".java") && !file.getFileName().toLowerCase().contains("/test/")) {
                     this.logger.debug("First java file found: " + file.getFileName());
                     return true;
                 }
@@ -360,7 +360,7 @@ public class ProjectScanner {
         if (compare != null) {
             GHCommit.File[] modifiedFiles = compare.getFiles();
             for (GHCommit.File file : modifiedFiles) {
-                if (file.getFileName().toLowerCase().contains("test") && file.getFileName().endsWith(".java")) {
+                if (file.getFileName().toLowerCase().contains("/test/") && file.getFileName().endsWith(".java")) {
                     this.logger.debug("First probable test file found: " + file.getFileName());
                     return true;
                 }

--- a/repairnator/repairnator-scanner/src/test/java/fr/inria/spirals/repairnator/scanner/ProjectScannerTest.java
+++ b/repairnator/repairnator-scanner/src/test/java/fr/inria/spirals/repairnator/scanner/ProjectScannerTest.java
@@ -129,7 +129,8 @@ public class ProjectScannerTest {
 
         BuildToBeInspected expectedBuildToBeInspected = new BuildToBeInspected(buildFailing, buildNextPassing, ScannedBuildStatus.FAILING_AND_PASSING, "test");
         BuildToBeInspected obtainedBTB = projectScanner.getBuildToBeInspected(buildNextPassing);
-        assertEquals(expectedBuildToBeInspected, obtainedBTB);
+        assertEquals(expectedBuildToBeInspected.getBuggyBuild().getId(), obtainedBTB.getBuggyBuild().getId());
+        assertEquals(expectedBuildToBeInspected.getPatchedBuild().getId(), obtainedBTB.getPatchedBuild().getId());
     }
 
     @Test

--- a/repairnator/repairnator-scanner/src/test/java/fr/inria/spirals/repairnator/scanner/ProjectScannerTest.java
+++ b/repairnator/repairnator-scanner/src/test/java/fr/inria/spirals/repairnator/scanner/ProjectScannerTest.java
@@ -109,8 +109,8 @@ public class ProjectScannerTest {
 
     @Test
     public void testGetBuildToBeInspectedWithPassingWithPreviousFailingFromPR() {
-        long buildIdFailing = 230022061; // inria/spoon
-        long buildIdNextPassing = 230049446;
+        long buildIdFailing = 324127095; // inria/spoon
+        long buildIdNextPassing = 324525330;
         RepairnatorConfig config = RepairnatorConfig.getInstance();
         config.setLauncherMode(LauncherMode.BEARS);
 

--- a/repairnator/repairnator-scanner/src/test/java/fr/inria/spirals/repairnator/scanner/ProjectScannerTest.java
+++ b/repairnator/repairnator-scanner/src/test/java/fr/inria/spirals/repairnator/scanner/ProjectScannerTest.java
@@ -157,4 +157,60 @@ public class ProjectScannerTest {
         BuildToBeInspected obtainedBTB = projectScanner.getBuildToBeInspected(buildNextPassing);
         assertEquals(expectedBuildToBeInspected, obtainedBTB);
     }
+
+    /*
+        The pair of builds is failing and passing.
+        This pair should not be selected by the scanner, i.e. a BuildToBeInspected should not be created,
+        because the failing build did not fail in Travis due to test failure.
+     */
+    @Test
+    public void testGetBuildToBeInspectedWithPassingBuildWithPreviousFailingBuildBears() {
+        long buildIdFailing = 325003763; // inria/spoon
+        long buildIdNextPassing = 325005624;
+        RepairnatorConfig config = RepairnatorConfig.getInstance();
+        config.setLauncherMode(LauncherMode.BEARS);
+
+        Optional<Build> buildOptional = config.getJTravis().build().fromId(buildIdFailing);
+        assertTrue(buildOptional.isPresent());
+        Build buildFailing = buildOptional.get();
+        assertEquals(StateType.FAILED, buildFailing.getState());
+
+        buildOptional = config.getJTravis().build().fromId(buildIdNextPassing);
+        assertTrue(buildOptional.isPresent());
+        Build buildNextPassing = buildOptional.get();
+        assertEquals(StateType.PASSED, buildNextPassing.getState());
+
+        ProjectScanner projectScanner = new ProjectScanner(new Date(), new Date(), "test");
+
+        BuildToBeInspected obtainedBTB = projectScanner.getBuildToBeInspected(buildNextPassing);
+        assertEquals(null, obtainedBTB);
+    }
+
+    /*
+        The pair of builds is passing and passing.
+        This pair should not be selected by the scanner, i.e. a BuildToBeInspected should not be created,
+        because there is no java file changed between the two builds (there is only test file).
+     */
+    @Test
+    public void testGetBuildToBeInspectedWithPassingBuildWithPreviousPassingBuildBears() {
+        long buildIdPassing = 323802157; // inria/spoon
+        long buildIdNextPassing = 323823511;
+        RepairnatorConfig config = RepairnatorConfig.getInstance();
+        config.setLauncherMode(LauncherMode.BEARS);
+
+        Optional<Build> buildOptional = config.getJTravis().build().fromId(buildIdPassing);
+        assertTrue(buildOptional.isPresent());
+        Build buildPassing = buildOptional.get();
+        assertEquals(StateType.PASSED, buildPassing.getState());
+
+        buildOptional = config.getJTravis().build().fromId(buildIdNextPassing);
+        assertTrue(buildOptional.isPresent());
+        Build buildNextPassing = buildOptional.get();
+        assertEquals(StateType.PASSED, buildNextPassing.getState());
+
+        ProjectScanner projectScanner = new ProjectScanner(new Date(), new Date(), "test");
+
+        BuildToBeInspected obtainedBTB = projectScanner.getBuildToBeInspected(buildNextPassing);
+        assertEquals(null, obtainedBTB);
+    }
 }

--- a/repairnator/repairnator-scanner/src/test/java/fr/inria/spirals/repairnator/scanner/ProjectScannerTest.java
+++ b/repairnator/repairnator-scanner/src/test/java/fr/inria/spirals/repairnator/scanner/ProjectScannerTest.java
@@ -165,8 +165,8 @@ public class ProjectScannerTest {
      */
     @Test
     public void testGetBuildToBeInspectedWithPassingBuildWithPreviousFailingBuildBears() {
-        long buildIdFailing = 325003763; // inria/spoon
-        long buildIdNextPassing = 325005624;
+        long buildIdFailing = 230022061; // inria/spoon
+        long buildIdNextPassing = 230049446;
         RepairnatorConfig config = RepairnatorConfig.getInstance();
         config.setLauncherMode(LauncherMode.BEARS);
 


### PR DESCRIPTION
The scanner for Bears is bringing a lot of pairs of builds that should not enter for reproduction:

1) when we have a pair of failed and passed builds, it should be checked if the failed build failed in Travis due to test failure;
2) when we have a pair of passed and passed builds, it should be checked if there is one java file between the two builds that is not test file.

This PR fixes that.