### PR TITLE
Changes to maven-repair to implement a safemode

### DIFF
--- a/maven-repair/src/main/java/com/github/tdurieux/repair/maven/plugin/NPEFixSafeMojo.java
+++ b/maven-repair/src/main/java/com/github/tdurieux/repair/maven/plugin/NPEFixSafeMojo.java
@@ -60,8 +60,9 @@ import java.util.Set;
 public class NPEFixSafeMojo extends AbstractRepairMojo {
 
     // taking the NpeFix version from Thomas' own Maven Repo
-    // https://github.com/tdurieux/maven-repository/tree/master/releases/fr/inria/spirals/npefix
-    private static String HARDCODED_NPEFIX_VERSION = "0.7";
+    // https://github.com/tdurieux/maven-repository/tree/master/releases/fr/inria/spirals/npefix (release)
+    // https://github.com/tdurieux/maven-repository/tree/master/snapshots/fr/inria/spirals/npefix (snapshot)
+    private static String HARDCODED_NPEFIX_VERSION = "0.8-SNAPSHOT";
     /**
      * Location of the file.
      */

--- a/maven-repair/src/main/java/com/github/tdurieux/repair/maven/plugin/NPEFixSafeMojo.java
+++ b/maven-repair/src/main/java/com/github/tdurieux/repair/maven/plugin/NPEFixSafeMojo.java
@@ -59,6 +59,8 @@ import java.util.Set;
         requiresDependencyResolution = ResolutionScope.TEST)
 public class NPEFixSafeMojo extends AbstractRepairMojo {
 
+    // taking the NpeFix version from Thomas' own Maven Repo
+    // https://github.com/tdurieux/maven-repository/tree/master/releases/fr/inria/spirals/npefix
     private static String HARDCODED_NPEFIX_VERSION = "0.7";
     /**
      * Location of the file.

--- a/maven-repair/src/main/java/com/github/tdurieux/repair/maven/plugin/NPEFixSafeMojo.java
+++ b/maven-repair/src/main/java/com/github/tdurieux/repair/maven/plugin/NPEFixSafeMojo.java
@@ -1,0 +1,327 @@
+package com.github.tdurieux.repair.maven.plugin;
+
+import exceptionparser.StackTrace;
+import exceptionparser.StackTraceElement;
+import exceptionparser.StackTraceParser;
+import fr.inria.spirals.npefix.config.Config;
+import fr.inria.spirals.npefix.main.DecisionServer;
+import fr.inria.spirals.npefix.main.all.DefaultRepairStrategy;
+import fr.inria.spirals.npefix.main.all.Launcher;
+import fr.inria.spirals.npefix.main.all.TryCatchRepairStrategy;
+import fr.inria.spirals.npefix.resi.CallChecker;
+import fr.inria.spirals.npefix.resi.context.Decision;
+import fr.inria.spirals.npefix.resi.context.Lapse;
+import fr.inria.spirals.npefix.resi.context.NPEOutput;
+import fr.inria.spirals.npefix.resi.exception.NoMoreDecision;
+import fr.inria.spirals.npefix.resi.selector.ExplorerSelector;
+import fr.inria.spirals.npefix.resi.selector.GreedySelector;
+import fr.inria.spirals.npefix.resi.selector.MonoExplorerSelector;
+import fr.inria.spirals.npefix.resi.selector.RandomSelector;
+import fr.inria.spirals.npefix.resi.selector.SafeMonoSelector;
+import fr.inria.spirals.npefix.resi.selector.Selector;
+import fr.inria.spirals.npefix.resi.strategies.NoStrat;
+import fr.inria.spirals.npefix.resi.strategies.ReturnType;
+import fr.inria.spirals.npefix.resi.strategies.Strat1A;
+import fr.inria.spirals.npefix.resi.strategies.Strat1B;
+import fr.inria.spirals.npefix.resi.strategies.Strat2A;
+import fr.inria.spirals.npefix.resi.strategies.Strat2B;
+import fr.inria.spirals.npefix.resi.strategies.Strat3;
+import fr.inria.spirals.npefix.resi.strategies.Strat4;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.plugins.surefire.report.ReportTestCase;
+import org.apache.maven.plugins.surefire.report.ReportTestSuite;
+import org.apache.maven.plugins.surefire.report.SurefireReportParser;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.reporting.MavenReportException;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+@Mojo( name = "npefix-safe", aggregator = true,
+        defaultPhase = LifecyclePhase.TEST,
+        requiresDependencyResolution = ResolutionScope.TEST)
+public class NPEFixSafeMojo extends AbstractRepairMojo {
+
+    private static String HARDCODED_NPEFIX_VERSION = "0.7";
+    /**
+     * Location of the file.
+     */
+    @Parameter( defaultValue = "${project.build.directory}/npefix", property = "outputDir", required = true )
+    private File outputDirectory;
+
+    @Parameter( defaultValue = "${project.build.directory}/npefix", property = "resultDir", required = true )
+    private File resultDirectory;
+
+    @Parameter( defaultValue = "safe-mono", property = "selector", required = true )
+    private String selector;
+
+    @Parameter( defaultValue = "100", property = "laps", required = true )
+    private int nbIteration;
+
+    @Parameter( defaultValue = "class", property = "scope", required = true )
+    private String scope;
+
+    @Parameter( defaultValue = "default", property = "strategy", required = true )
+    private String repairStrategy;
+
+    private NPEOutput result;
+
+    public void execute() throws MojoExecutionException {
+        List<Pair<String, Set<File>>> npeTests = getNPETest();
+
+        try {
+            File currentDir = new File(".").getCanonicalFile();
+            Config.CONFIG.setRootProject(currentDir.toPath().toAbsolutePath());
+        } catch (IOException e) {
+            getLog().error("Error while setting the root project path, the created patches might have absolute paths.");
+        }
+        final List<URL> dependencies = getClasspath();
+        Set<File> sourceFolders = new HashSet<>();
+        if ("project".equals(scope)) {
+            sourceFolders = new HashSet<>(getSourceFolders());
+        } else {
+            for (Pair<String, Set<File>> test : npeTests) {
+                sourceFolders.addAll(test.getValue());
+            }
+        }
+        List<File> testFolders = getTestFolders();
+
+        classpath(dependencies);
+
+        if (npeTests.isEmpty()) {
+            throw new RuntimeException("No failing test with NullPointerException or the NPE occurred outside the source.");
+        }
+
+        final String[] sources = new String[sourceFolders.size() /* + testFolders.size()*/];
+        int indexSource = 0;
+
+        /*for (int i = 0; i < testFolders.size(); i++, indexSource++) {
+            String s = testFolders.get(i);
+            sources[indexSource] = s;
+            System.out.println("Test: " + s);
+        }*/
+        for (File sourceFolder : sourceFolders) {
+            sources[indexSource] = sourceFolder.getAbsolutePath();
+            System.out.println("Source: " + sourceFolder);
+            indexSource++;
+        }
+        File binFolder = new File(outputDirectory.getAbsolutePath() + "/npefix-bin");
+
+        try {
+            dependencies.add(binFolder.toURI().toURL());
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+        if (!binFolder.exists()) {
+            binFolder.mkdirs();
+        }
+        int complianceLevel = getComplianceLevel();
+        complianceLevel = Math.max(complianceLevel, 5);
+        System.out.println("ComplianceLevel: " + complianceLevel);
+
+        Date initDate = new Date();
+
+        DefaultRepairStrategy strategy = new DefaultRepairStrategy(sources);
+        if (repairStrategy.toLowerCase().equals("TryCatch".toLowerCase())) {
+            strategy = new TryCatchRepairStrategy(sources);
+        }
+        Launcher  npefix = new Launcher(sources, outputDirectory.getAbsolutePath() + "/npefix-output", binFolder.getAbsolutePath(), classpath(dependencies), complianceLevel, strategy);
+
+        //npefix.getSpoon().getEnvironment().setAutoImports(false);
+
+        npefix.instrument();
+
+
+        List<String> tests = new ArrayList<>();
+        for (Pair<String, Set<File>> npeTest : npeTests) {
+            if (!tests.contains(npeTest.getKey())) {
+                tests.add(npeTest.getKey());
+            }
+        }
+        this.result = run(npefix, tests);
+
+
+        spoon.Launcher spoon = new spoon.Launcher();
+        for (File s : sourceFolders) {
+            spoon.addInputResource(s.getAbsolutePath());
+        }
+
+        spoon.getModelBuilder().setSourceClasspath(classpath(dependencies).split(File.pathSeparatorChar + ""));
+        spoon.buildModel();
+
+        JSONObject jsonObject = result.toJSON(spoon);
+        jsonObject.put("endInit", initDate.getTime());
+        try {
+            for (Decision decision : CallChecker.strategySelector.getSearchSpace()) {
+                jsonObject.append("searchSpace", decision.toJSON());
+            }
+            FileWriter writer = new FileWriter(resultDirectory.getAbsolutePath() + "/patches_" + new Date().getTime() + ".json");
+            jsonObject.write(writer);
+            writer.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private NPEOutput run(Launcher  npefix, List<String> npeTests) {
+        switch (selector.toLowerCase()) {
+        case "safe-mono":
+            return multipleRuns(npefix, npeTests, new SafeMonoSelector());
+        }
+        return null;
+    }
+
+    private NPEOutput multipleRuns(Launcher  npefix, List<String> npeTests, Selector selector) {
+        DecisionServer decisionServer = new DecisionServer(selector);
+        decisionServer.startServer();
+
+        NPEOutput output = new NPEOutput();
+
+        int countError = 0;
+        while (output.size() < nbIteration) {
+            if(countError > 5) {
+                break;
+            }
+            try {
+                List<Lapse> result = npefix.run(selector, npeTests);
+                if(result.isEmpty()) {
+                    countError++;
+                    continue;
+                }
+                boolean isEnd = true;
+                for (int i = 0; i < result.size() && isEnd; i++) {
+                    Lapse lapse = result.get(i);
+                    if (lapse.getOracle().getError() != null) {
+                        isEnd = isEnd && lapse.getOracle().getError().contains(NoMoreDecision.class.getSimpleName()) || lapse.getDecisions().isEmpty();
+                    } else {
+                        isEnd = false;
+                    }
+                }
+                if (isEnd) {
+                    // no more decision
+                    countError++;
+                    continue;
+                }
+                countError = 0;
+                if(output.size() + result.size() > nbIteration) {
+                    output.addAll(result.subList(0, (nbIteration - output.size())));
+                } else {
+                    output.addAll(result);
+                }
+            } catch (OutOfMemoryError e) {
+                e.printStackTrace();
+                countError++;
+                continue;
+            } catch (Exception e) {
+                if(e.getCause() instanceof OutOfMemoryError) {
+                    countError++;
+                    continue;
+                }
+                e.printStackTrace();
+                countError++;
+                continue;
+            }
+            System.out.println("Multirun " + output.size() + "/" + nbIteration + " " + ((int)(output.size()/(double)nbIteration * 100)) + "%");
+        }
+        output.setEnd(new Date());
+        return output;
+    }
+
+    private String classpath(List<URL> dependencies) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < dependencies.size(); i++) {
+            URL s = dependencies.get(i);
+            sb.append(s.getPath()).append(File.pathSeparatorChar);
+        }
+        final Artifact artifact =artifactFactory.createArtifact("fr.inria.spirals","npefix", HARDCODED_NPEFIX_VERSION, null, "jar");
+        File file = new File(localRepository.getBasedir() + "/" + localRepository.pathOf(artifact));
+
+        sb.append(file.getAbsoluteFile());
+        System.out.println(sb);
+        return sb.toString();
+    }
+
+    private File getSurefireReportsDirectory( MavenProject subProject ) {
+        String buildDir = subProject.getBuild().getDirectory();
+        return new File( buildDir + "/surefire-reports" );
+    }
+
+    private List<Pair<String, Set<File>>> getNPETest() {
+        List<Pair<String, Set<File>>> output = new ArrayList<>();
+
+        for (MavenProject mavenProject : reactorProjects) {
+            File surefireReportsDirectory = getSurefireReportsDirectory(mavenProject);
+            SurefireReportParser parser = new SurefireReportParser(Collections.singletonList(surefireReportsDirectory), Locale.ENGLISH, new NullConsoleLogger());
+            try {
+                List<ReportTestSuite> testSuites = parser.parseXMLReportFiles();
+                for (int i = 0; i < testSuites.size(); i++) {
+                    ReportTestSuite reportTestSuite = testSuites.get(i);
+                    List<ReportTestCase> testCases = reportTestSuite.getTestCases();
+                    for (int j = 0; j < testCases.size(); j++) {
+                        ReportTestCase reportTestCase = testCases.get(j);
+                        if (reportTestCase.hasFailure() && reportTestCase.getFailureDetail() != null) {
+                            try {
+                                StackTrace stackTrace = StackTraceParser.parse(reportTestCase.getFailureDetail());
+                                StackTrace causedBy = stackTrace.getCausedBy();
+                                while (causedBy != null) {
+                                    stackTrace = causedBy;
+                                    causedBy = stackTrace.getCausedBy();
+                                }
+                                if (stackTrace.getExceptionType().contains("NullPointerException") || repairStrategy.toLowerCase().equals("TryCatch".toLowerCase())) {
+                                    Set<File> files = new HashSet<>();
+                                    for (StackTraceElement stackTraceElement : stackTrace.getElements()) {
+                                        String path = stackTraceElement.getMethod().substring(0, stackTraceElement.getMethod().lastIndexOf(".")).replace(".", "/") + ".java";
+                                        if (path.contains("$")) {
+                                            path = path.substring(0, path.indexOf("$")) + ".java";
+                                        }
+                                        if ("package".equals(scope)) {
+                                            path = path.substring(0, path.lastIndexOf("/"));
+                                        }
+                                        for (MavenProject project : reactorProjects) {
+                                            File file = new File(project.getBuild().getSourceDirectory() + "/" + path);
+                                            if (file.exists()) {
+                                                files.add(file);
+                                                break;
+                                            }
+                                        }
+                                        if (!"stack".equals(scope)) {
+                                            break;
+                                        }
+                                    }
+                                    output.add(new Pair<>(reportTestCase.getFullClassName() + "#" + reportTestCase.getName(), files));
+                                }
+                            } catch (StackTraceParser.ParseException e) {
+                                e.printStackTrace();
+                            }
+                        }
+                    }
+                }
+            } catch (MavenReportException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return output;
+    }
+
+    public NPEOutput getResult() {
+        return result;
+    }
+}

--- a/maven-repair/src/test/java/com/github/tdurieux/repair/maven/plugin/NPEFixSafeMojoTest.java
+++ b/maven-repair/src/test/java/com/github/tdurieux/repair/maven/plugin/NPEFixSafeMojoTest.java
@@ -1,0 +1,35 @@
+package com.github.tdurieux.repair.maven.plugin;
+
+import org.apache.maven.plugin.Mojo;
+
+import java.io.File;
+
+public class NPEFixSafeMojoTest extends BetterAbstractMojoTestCase {
+    private final String projectPath = "src/test/resources/projects/example2/";
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        Process mvn_clean_test = Runtime.getRuntime().exec("mvn clean test", null,  new File(projectPath));
+        mvn_clean_test.waitFor();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        Process mvn_clean = Runtime.getRuntime().exec("mvn clean", null,    new File(projectPath));
+        mvn_clean.waitFor();
+    }
+
+    public void testNPEFixRepair() throws Exception {
+        File f = getTestFile(projectPath + "pom.xml");
+        Mojo mojo = lookupConfiguredMojo(f, "npefix-safe");
+        assertNotNull( mojo );
+        assertTrue("Wrong class: "+mojo, mojo instanceof NPEFixSafeMojo);
+
+        NPEFixSafeMojo repair = (NPEFixSafeMojo) mojo;
+        repair.execute();
+
+        assertTrue(repair.getResult().size() > 0);
+    }
+}


### PR DESCRIPTION
In issue #640 we wish to have a safemode for NPEFix, and since we are currently using maven-repair for the NPEFix, this means we have to make some small changes to maven-repair as well. This PR attempts to make these changes.