### PR TITLE
Change checked out fork in RTScanner test

### DIFF
--- a/repairnator/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestRTScanner.java
+++ b/repairnator/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestRTScanner.java
@@ -39,10 +39,9 @@ public class TestRTScanner {
         assertFalse(result);
     }
 
-    @Ignore
+    @Test
     public void testRepositoryWithoutCheckstyleIsInteresting() {
-        // TODO find another interesting repo
-        String slug = "nosan/embedded-cassandra";
+        String slug = "repairnator/embedded-cassandra";
         RepairnatorConfig.getInstance().setLauncherMode(LauncherMode.CHECKSTYLE);
         Optional<Repository> repositoryOptional = RepairnatorConfig.getInstance().getJTravis().repository().fromSlug(slug);
         assertTrue(repositoryOptional.isPresent());


### PR DESCRIPTION
Closes #860 in a way according to the discussion in the aforementioned issue. 

Still need to give travis-ci access to the repairnator organization, but after that there should be no faults.